### PR TITLE
feat: new commands

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -1,0 +1,19 @@
+# Misc commands
+
+This directory contains various scripts that are not part of the main codebase, but are useful for various tasks, both have dry-run mode.
+
+- fix-order.php
+
+This script is a wp-cli command that can be used to fix the order of the menu items in the database. It is useful when the order of the menu items is incorrect, and you want to fix it without having to manually reorder the items in the admin interface.
+
+```bash
+wp eval-file fix-order.php <book-id> dry-run
+```
+
+- fix-social-media-share.php
+
+This script is a wp-cli command that can be used to fix the social media metadata options in the database. It is useful when the social media metadata options are incorrect, and you want to fix it without having to manually update the options in the admin interface.
+
+```bash
+wp eval-file fix-social.php social fix dry-run
+```

--- a/commands/fix-order.php
+++ b/commands/fix-order.php
@@ -1,0 +1,109 @@
+<?php
+
+use Pressbooks\Book;
+
+class Ordering
+{
+
+    public static function init()
+    {
+        WP_CLI::add_command('books fix-order', __CLASS__);
+    }
+
+    /**
+     * Sync book menu order.
+     *
+     * ## OPTIONS
+     *
+     * <book_id>
+     * : The ID of the book to process.
+     *
+     * [--dry-run]
+     * : Perform a dry run without making any changes.
+     *
+     * ## EXAMPLES
+     *
+     * wp books fix-order 123
+     * wp books fix-order 123 --dry-run
+     */
+    public function __invoke($args, $assoc_args): void
+    {
+        $book_id = $args[0];
+        $dry_run = isset($assoc_args['dry-run']);
+
+        if (!is_numeric($book_id)) {
+            WP_CLI::error("Please provide a valid book ID.");
+        }
+
+        global $wpdb;
+
+        if (!get_site($book_id)) {
+            WP_CLI::error("Book ID {$book_id} is not a book.");
+        }
+
+        switch_to_blog($book_id);
+
+        collect(Book::getBookStructure())->each(function ($group, $key) use ($wpdb, $dry_run) {
+            if ($key === 'front-matter' || $key === 'back-matter') {
+                collect($group)->each(function ($item, $index) use ($wpdb, $dry_run) {
+                    $newMenuOrder = $index + 1;
+                    if ($dry_run) {
+                        WP_CLI::log("Would update post ID {$item['ID']} to menu_order {$newMenuOrder}");
+                    } else {
+                        $wpdb->update(
+                            $wpdb->posts,
+                            ['menu_order' => $newMenuOrder],
+                            ['ID' => $item['ID']]
+                        );
+                    }
+                });
+                return;
+            }
+
+            if ($key === 'part') {
+                collect($group)->each(function ($item, $index) use ($wpdb, $dry_run) {
+                    $newMenuOrder = $index + 1;
+                    if ($dry_run) {
+                        WP_CLI::log("Would update post ID {$item['ID']} to menu_order {$newMenuOrder}");
+                    } else {
+                        $wpdb->update(
+                            $wpdb->posts,
+                            ['menu_order' => $newMenuOrder],
+                            ['ID' => $item['ID']]
+                        );
+                    }
+
+                    collect($item['chapters'])->each(function ($child, $childIndex) use ($wpdb, $dry_run) {
+                        $newMenuOrder = $childIndex + 1;
+                        if ($dry_run) {
+                            WP_CLI::log("Would update chapter ID {$child['ID']} to menu_order {$newMenuOrder}");
+                        } else {
+                            $wpdb->update(
+                                $wpdb->posts,
+                                ['menu_order' => $newMenuOrder],
+                                ['ID' => $child['ID']]
+                            );
+                        }
+                    });
+                });
+            }
+        });
+
+        restore_current_blog();
+
+        if ($dry_run) {
+            WP_CLI::success("Dry run complete. No changes were made.");
+        } else {
+            WP_CLI::success("Menu orders updated successfully.");
+        }
+    }
+}
+
+Ordering::init();
+$arguments = ['books', 'fix-order'];
+
+if (isset($args[0])) {
+    $arguments[] = $args[0];
+}
+
+WP_CLI::run_command($arguments, isset($args[1]) && $args[1] === 'dry-run' ? ['dry-run' => true] : []);

--- a/commands/fix-social.php
+++ b/commands/fix-social.php
@@ -1,0 +1,95 @@
+<?php
+
+class FixSocial
+{
+
+    public static function init()
+    {
+        WP_CLI::add_command('social fix', __CLASS__);
+    }
+
+    public function __invoke($args, $assoc_args): void
+    {
+        WP_CLI::success("Fixing social_media options at network level");
+        global $wpdb;
+        $sites = $wpdb->get_col("SELECT blog_id FROM {$wpdb->blogs}");
+
+        $is_dry_run = isset($assoc_args['dry-run']);
+        $remove_twitterx = isset($assoc_args['no-twitter-x']);
+
+        foreach ($sites as $site_id) {
+            // Skip main site
+            if ($site_id === 1) {
+                continue;
+            }
+
+            $defaults = [
+                'social_media_options' => [],
+            ];
+
+            switch_to_blog($site_id);
+            WP_CLI::success("Processing site {$site_id}");
+            $current_web_options = get_option('pressbooks_theme_options_web');
+
+            if (!is_array($current_web_options)) {
+                WP_CLI::log("Weird, there are no pressbooks_theme_options_web for site: {$site_id}");
+                continue;
+            }
+
+            // skip if this site has already social_media_options
+            if (!empty($current_web_options['social_media_options'])) {
+                WP_CLI::log("Skip social_media_options for site {$site_id}, already in place!");
+                continue;
+            }
+
+            // enable options if they were enabled only
+            if (!empty($current_web_options['social_media'])) {
+                WP_CLI::success("Enabling sharing options on site: {$site_id}");
+                $defaults['social_media_options'] = [
+                    'twitter',
+                    'linkedin',
+                    'email'
+                ];
+                // remove twitter if the argument is true
+                if ($remove_twitterx) {
+                    WP_CLI::success("Removing X/Twitter for site: {$site_id}");
+                    unset($defaults['social_media_options'][0]);
+                }
+            }
+
+            // remove old social media options key
+            unset($current_web_options['social_media']);
+
+            // preserve current settings and merge new social media options key
+            $new_web_options = [...$current_web_options, 'social_media_options' => $defaults['social_media_options']];
+
+            if ($is_dry_run) {
+                WP_CLI::log("Dry-run: Would create social_media_options for site {$site_id} with: " . print_r($new_web_options, true));
+            } else {
+                update_option('pressbooks_theme_options_web', $new_web_options);
+                WP_CLI::success("Created social_media_options for site {$site_id}");
+            }
+            restore_current_blog();
+        }
+    }
+}
+
+FixSocial::init();
+$arguments = ['social', 'fix'];
+// Dynamically parse and map arguments
+$options = [];
+
+foreach (array_slice($args, 2) as $arg) {
+    switch ($arg) {
+        case 'no-twitter-x':
+            $options['no-twitter-x'] = true;
+            break;
+        case 'dry-run':
+            $options['dry-run'] = true;
+            break;
+        default:
+            WP_CLI::error("Unknown parameter: $arg");
+    }
+}
+
+WP_CLI::run_command($arguments, $options);


### PR DESCRIPTION
This pull request introduces two new WP-CLI commands to help manage book menu orders and social media metadata options. The changes include the addition of two scripts and their corresponding documentation.

### New WP-CLI Commands:

* **Book Menu Order Fixer:**
  - Added `fix-order.php` script which provides a command to fix the order of menu items in a book's database. It includes a dry-run mode to preview changes without applying them.
  - Updated `commands/README.md` to document the usage of the `fix-order.php` script.

* **Social Media Metadata Fixer:**
  - Added `fix-social.php` script which provides a command to fix social media metadata options in the database. It includes options to perform a dry-run and to exclude Twitter/X from the metadata.
  - Updated `commands/README.md` to document the usage of the `fix-social.php` script.