### PR TITLE
feat: pbshare.sh

### DIFF
--- a/deploying/README.md
+++ b/deploying/README.md
@@ -1,0 +1,78 @@
+# README
+
+## Script Overview
+This script is a powerful and convenient tool to manage the dynamic setup and reversion of your WordPress development environment. It works with **Lando**, **ngrok**, and your `.env` file to ensure seamless transitions between local and public-facing development environments. The script offers two modes of operation:
+
+- **ON mode**: Dynamically configures your environment to use a provided ngrok subdomain.
+- **OFF mode**: Reverts the environment to its original state.
+
+## Features
+1. **Dynamic Domain Configuration**: Automatically updates WordPress URLs and `.env` values to match the provided ngrok subdomain.
+2. **Reversion**: Reverts WordPress database and `.env` settings to their original values.
+3. **Automatic Port Extraction**: Extracts the correct localhost port from the `appserver_nginx` service in Lando.
+4. **Seamless ngrok Integration**: Starts ngrok with the appropriate configurations to expose your local environment.
+
+## Benefits
+- **Automation**: Eliminates manual effort to update URLs, ports, and `.env` configurations.
+- **Efficiency**: Quickly toggle between local and public environments.
+- **Error Reduction**: Automates repetitive tasks, reducing the risk of human error.
+- **Dynamic Reversion**: Reads the current domain from `.env` to ensure accurate reversion of changes.
+
+## Usage
+### Prerequisites
+Ensure the following tools are installed and configured:
+- [Lando](https://docs.lando.dev/)
+- [ngrok](https://ngrok.com/)
+- `jq` for parsing JSON
+- A valid `.env` file with the following keys:
+  - `WP_HOME`
+  - `DOMAIN_CURRENT_SITE`
+
+### Running the Script
+#### ON Mode
+To set up the environment with a specific ngrok subdomain:
+```bash
+./pbshare.sh <shared-url>
+```
+- Replace `<shared-url>` with your desired ngrok subdomain (e.g., `app.ngrok.io`).
+
+#### OFF Mode
+To revert the environment to its original state:
+```bash
+./pbshare.sh
+```
+
+## How It Works
+### ON Mode
+1. **WordPress Search-Replace**: Updates all database tables, replacing `pressbooks.test` with the provided ngrok subdomain.
+2. **.env Update**: Updates `WP_HOME` and `DOMAIN_CURRENT_SITE` to use the ngrok subdomain.
+3. **Port Extraction**: Dynamically retrieves the correct localhost port from the `appserver_nginx` service in Lando.
+4. **ngrok Start**: Launches ngrok with the extracted port and configured domain.
+
+### OFF Mode
+1. **Domain Extraction**: Reads the current `DOMAIN_CURRENT_SITE` from `.env`.
+2. **WordPress Search-Replace**: Reverts all database tables, replacing the current domain with `pressbooks.test`.
+3. **.env Reversion**: Restores `WP_HOME` and `DOMAIN_CURRENT_SITE` to their original values.
+4. **ngrok Stop**: Stops any running ngrok processes.
+
+## Example
+### Enable Environment
+```bash
+./pbshare.sh app.ngrok.io
+```
+This sets up your environment to use the ngrok subdomain `app.ngrok.io`.
+
+### Revert Environment
+```bash
+./pbshare.sh
+```
+This reverts the environment to its original state using `pressbooks.test`.
+
+## Troubleshooting
+- Ensure `jq` is installed and accessible in your `$PATH`.
+- Verify that the `.env` file contains the required keys (`WP_HOME` and `DOMAIN_CURRENT_SITE`).
+- Check the output of `lando info --format json` to confirm the `appserver_nginx` service is correctly configured.
+
+## License
+This script is open-source and provided under the MIT License. Feel free to modify and use it in your projects.
+

--- a/deploying/pbshare.sh
+++ b/deploying/pbshare.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+usage() {
+  echo "Usage: $0 [<shared-url>]"
+  echo "If <shared-url> is provided, the script sets up the environment (ON mode)."
+  echo "If no arguments are provided, the script reverts the changes (OFF mode)."
+}
+
+# Check if no arguments are provided (OFF mode)
+if [ $# -eq 0 ]; then
+  echo "Reverting environment to default (OFF mode)..."
+
+  # Step 1: Revert search-replace in WordPress database
+  echo "Reverting WP search-replace..."
+  CURRENT_SITE=$(grep -E '^DOMAIN_CURRENT_SITE=' .env | cut -d '=' -f2)
+  cd web && lando wp search-replace "$CURRENT_SITE" "pressbooks.test" --all-tables && cd ..
+
+  # Step 2: Restore original .env values
+  echo "Restoring .env file..."
+  sed -i.bak -E "s|(WP_HOME=).*|\1https://pressbooks.test|g" .env
+  sed -i.bak -E "s|(DOMAIN_CURRENT_SITE=).*|\1pressbooks.test|g" .env
+
+  # Step 3: Stop `ngrok`
+  echo "Stopping ngrok..."
+  pkill -f "ngrok http"
+
+  echo "Environment reverted to default."
+  exit 0
+fi
+
+# If a domain is provided, execute ON mode
+SHARED_URL=$1
+echo "Setting up environment with shared URL: $SHARED_URL"
+
+# Step 1: Search-replace in WordPress database
+echo "Running WP search-replace..."
+cd web && lando wp search-replace pressbooks.test "$SHARED_URL" --all-tables && cd ..
+
+# Step 2: Update .env with WP_HOME and DOMAIN_CURRENT_SITE
+echo "Updating .env file..."
+sed -i.bak -E "s|(WP_HOME=).*|\1https://$SHARED_URL|g" .env
+sed -i.bak -E "s|(DOMAIN_CURRENT_SITE=).*|\1$SHARED_URL|g" .env
+
+# Step 3: Extract port from lando info
+echo "Extracting localhost port from lando info..."
+LANDO_INFO=$(lando info --format json)
+# Extract port from the appserver_nginx service in lando info
+LOCALHOST_PORT=$(echo "$LANDO_INFO" | jq -r '.[] | select(.service == "appserver_nginx") | .urls[] | select(startswith("http://localhost:"))' | awk -F':' '{print $3}' | awk -F'/' '{print $1}')
+
+if [ -z "$LOCALHOST_PORT" ]; then
+  echo "Error: Could not extract port from lando info."
+  exit 1
+fi
+# Step 4: Run ngrok
+echo "Starting ngrok..."
+ngrok http "$LOCALHOST_PORT" --domain "$SHARED_URL"


### PR DESCRIPTION
This pull request introduces a new script and accompanying documentation to manage the dynamic setup and reversion of a WordPress development environment using Lando, ngrok, and a `.env` file. The changes include a detailed `README.md` and the `pbshare.sh` script.

Documentation:

* [`deploying/README.md`](diffhunk://#diff-f9891d02a53c527363403c679b621681257c71c2e65f81024d61e553466c8947R1-R78): Added a comprehensive README file detailing the script's purpose, features, benefits, usage instructions, and troubleshooting tips.

Script:

* [`deploying/pbshare.sh`](diffhunk://#diff-15a7b1e1d0556e36ce1f1d3ee72e639c0104191fe280c17209e1ae618a0babdbR1-R56): Implemented a bash script to dynamically configure or revert the WordPress development environment based on the provided ngrok subdomain. The script includes steps for search-replace in the WordPress database, updating the `.env` file, extracting the localhost port from Lando, and starting/stopping ngrok.